### PR TITLE
fix(neo-chess): handle piece movement and capture

### DIFF
--- a/apps/web/src/app/[locale]/(games)/neo-chess/referee.ts
+++ b/apps/web/src/app/[locale]/(games)/neo-chess/referee.ts
@@ -22,7 +22,7 @@ export default class Referee {
 
   // Assuming you have a function to handle piece capture
   capturePiece(x: number, y: number, boardState: Piece[]): Piece[] {
-    return boardState.filter(piece => !(piece.x === x && piece.y === y));
+    return boardState.filter((piece) => !(piece.x === x && piece.y === y));
   }
 
   private isPathClear(
@@ -66,7 +66,7 @@ export default class Referee {
     team: TeamType,
     firstMove: boolean,
     boardState: Piece[]
-  ): { isValid: boolean, updatedBoardState: Piece[] } {
+  ): { isValid: boolean; updatedBoardState: Piece[] } {
     const lastPosition = this.lastPositions.get(pieceId);
     const isOurTeam = team === TeamType.OURS;
 
@@ -141,6 +141,34 @@ export default class Referee {
         (isDiagonalMove ||
           horizontalDistance === 0 ||
           verticalDistance === 0) &&
+        this.isPathClear(
+          verticalDistance,
+          horizontalDistance,
+          boardState,
+          row,
+          column
+        ) &&
+        (!this.tileIsOccupied(column, row, boardState) ||
+          this.tileIsOccupiedByOpponent(column, row, team, boardState))
+      ) {
+        boardState = this.capturePiece(column, row, boardState);
+        return { isValid: true, updatedBoardState: boardState };
+      }
+    } else if (type === PieceType.KNIGHT) {
+      if (
+        ((Math.abs(horizontalDistance) === 1 &&
+          Math.abs(verticalDistance) === 2) ||
+          (Math.abs(horizontalDistance) === 2 &&
+            Math.abs(verticalDistance) === 1)) &&
+        (!this.tileIsOccupied(column, row, boardState) ||
+          this.tileIsOccupiedByOpponent(column, row, team, boardState))
+      ) {
+        boardState = this.capturePiece(column, row, boardState);
+        return { isValid: true, updatedBoardState: boardState };
+      }
+    } else if (type === PieceType.ROOK) {
+      if (
+        (horizontalDistance === 0 || verticalDistance === 0) &&
         this.isPathClear(
           verticalDistance,
           horizontalDistance,

--- a/apps/web/src/app/[locale]/(games)/neo-chess/referee.ts
+++ b/apps/web/src/app/[locale]/(games)/neo-chess/referee.ts
@@ -20,10 +20,14 @@ export default class Referee {
     return piece !== undefined && piece.team !== team;
   }
 
+  // Assuming you have a function to handle piece capture
+  capturePiece(x: number, y: number, boardState: Piece[]): Piece[] {
+    return boardState.filter(piece => !(piece.x === x && piece.y === y));
+  }
+
   private isPathClear(
     verticalDistance: number,
     horizontalDistance: number,
-    cellSize: number,
     boardState: Piece[],
     row: number,
     column: number
@@ -34,8 +38,8 @@ export default class Referee {
       horizontalDistance === 0 ? 0 : horizontalDistance > 0 ? 1 : -1;
     const steps =
       verticalDistance !== 0
-        ? Math.abs(verticalDistance) / Math.round(cellSize)
-        : Math.abs(horizontalDistance) / Math.round(cellSize);
+        ? Math.abs(verticalDistance)
+        : Math.abs(horizontalDistance);
 
     for (let i = 1; i < steps; i++) {
       let checkRow = 0;
@@ -58,12 +62,11 @@ export default class Referee {
     row: number,
     prevX: number,
     prevY: number,
-    cellSize: number,
     type: PieceType,
     team: TeamType,
     firstMove: boolean,
     boardState: Piece[]
-  ) {
+  ): { isValid: boolean, updatedBoardState: Piece[] } {
     const lastPosition = this.lastPositions.get(pieceId);
     const isOurTeam = team === TeamType.OURS;
 
@@ -84,7 +87,7 @@ export default class Referee {
       if (horizontalDistance === 0) {
         if (verticalDistance === pawnDirection) {
           if (!this.tileIsOccupied(column, row, boardState)) {
-            return true;
+            return { isValid: true, updatedBoardState: boardState };
           }
         } else if (
           verticalDistance === 2 * pawnDirection &&
@@ -92,7 +95,7 @@ export default class Referee {
           !this.tileIsOccupied(column, row - pawnDirection, boardState) &&
           !this.tileIsOccupied(column, row, boardState)
         ) {
-          return true;
+          return { isValid: true, updatedBoardState: boardState };
         }
       }
       // Diagonal capture
@@ -101,7 +104,8 @@ export default class Referee {
         verticalDistance === pawnDirection &&
         this.tileIsOccupiedByOpponent(column, row, team, boardState)
       ) {
-        return true;
+        boardState = this.capturePiece(column, row, boardState);
+        return { isValid: true, updatedBoardState: boardState };
       }
     } else if (type === PieceType.KING) {
       if (
@@ -112,7 +116,8 @@ export default class Referee {
           !this.tileIsOccupied(column, row, boardState) ||
           this.tileIsOccupiedByOpponent(column, row, team, boardState)
         ) {
-          return true;
+          boardState = this.capturePiece(column, row, boardState);
+          return { isValid: true, updatedBoardState: boardState };
         }
       }
     } else if (type === PieceType.BISHOP) {
@@ -121,7 +126,6 @@ export default class Referee {
         this.isPathClear(
           verticalDistance,
           horizontalDistance,
-          cellSize,
           boardState,
           row,
           column
@@ -129,7 +133,8 @@ export default class Referee {
         (!this.tileIsOccupied(column, row, boardState) ||
           this.tileIsOccupiedByOpponent(column, row, team, boardState))
       ) {
-        return true;
+        boardState = this.capturePiece(column, row, boardState);
+        return { isValid: true, updatedBoardState: boardState };
       }
     } else if (type === PieceType.QUEEN) {
       if (
@@ -139,7 +144,6 @@ export default class Referee {
         this.isPathClear(
           verticalDistance,
           horizontalDistance,
-          cellSize,
           boardState,
           row,
           column
@@ -147,10 +151,11 @@ export default class Referee {
         (!this.tileIsOccupied(column, row, boardState) ||
           this.tileIsOccupiedByOpponent(column, row, team, boardState))
       ) {
-        return true;
+        boardState = this.capturePiece(column, row, boardState);
+        return { isValid: true, updatedBoardState: boardState };
       }
     }
 
-    return false;
+    return { isValid: false, updatedBoardState: boardState };
   }
 }

--- a/apps/web/src/app/[locale]/(games)/neo-chess/use-dnd.ts
+++ b/apps/web/src/app/[locale]/(games)/neo-chess/use-dnd.ts
@@ -1,8 +1,8 @@
 'use client';
 
-import { PieceType, TeamType, pieces } from './pieceSetup';
+import { PieceType, TeamType, pieces as initialPieces } from './pieceSetup';
 import Referee from './referee';
-import React, { useRef } from 'react';
+import React, { useRef, useState } from 'react';
 
 export function useDragAndDrop(
   removePieceById: (id: string) => void,
@@ -12,6 +12,7 @@ export function useDragAndDrop(
   let activePiece: HTMLElement | null = null;
   let hasMoved = useRef(false);
   const referee = new Referee();
+  const [boardState, setBoardState] = useState(initialPieces); // Initial board state
 
   const touchStartPosition = useRef<{ x: number; y: number }>({ x: 0, y: 0 });
   const fixPosition = useRef<
@@ -132,10 +133,6 @@ export function useDragAndDrop(
 
     if (activePiece && chessboard && hasMoved.current) {
       const pieceId = activePiece.id;
-
-      const chessboardRect = chessboard.getBoundingClientRect();
-      const cellSize = chessboardRect.width / 10;
-
       const imageSrc = (activePiece as HTMLImageElement).src;
       const pieceMatch = imageSrc.match(/([bw])_(\w+)\.png$/);
       let pieceTeam: TeamType | null = null;
@@ -166,16 +163,17 @@ export function useDragAndDrop(
           cellCenter.current.nextRow,
           fixPosition.current[pieceId].column,
           fixPosition.current[pieceId].row,
-          cellSize,
           pieceType,
           pieceTeam,
           fixPosition.current[pieceId].firstMove,
-          pieces
+          boardState
         );
 
-        if (validMove) {
+        if (validMove.isValid) {
+          setBoardState(validMove.updatedBoardState);
+
           // Capture logic: Remove the captured piece based on position
-          const capturedPiece = pieces.find(
+          const capturedPiece = boardState.find(
             (piece) =>
               piece.x === cellCenter.current.nextColumn &&
               piece.y === cellCenter.current.nextRow &&
@@ -192,11 +190,11 @@ export function useDragAndDrop(
           );
 
           // Update the pieces array
-          const pieceIndex = pieces.findIndex((p) => p.id === pieceId);
-          if (pieceIndex !== -1 && pieces[pieceIndex]) {
-            pieces[pieceIndex].x = cellCenter.current.nextColumn;
-            pieces[pieceIndex].y = cellCenter.current.nextRow;
-            pieces[pieceIndex].firstMove = false;
+          const pieceIndex = boardState.findIndex((p) => p.id === pieceId);
+          if (pieceIndex !== -1 && boardState[pieceIndex]) {
+            boardState[pieceIndex].x = cellCenter.current.nextColumn;
+            boardState[pieceIndex].y = cellCenter.current.nextRow;
+            boardState[pieceIndex].firstMove = false;
           }
 
           activePiece.style.position = 'static';


### PR DESCRIPTION
- All pieces can now move normally and cannot move if there is a barrier (except for Knight).
- All pieces can now attack the opponent.
- The captured piece is then removed from both the board and the piece array.
----------
- Closes #58.
- Closes #59.
- Closes #64 .
- Closes #65 .
- Closes #67.
- Closes #68.