### PR TITLE
Limit scanner page to whitelisted users only and improve error handling

### DIFF
--- a/apps/db/supabase/migrations/20250703232000_add_whitelist_check.sql
+++ b/apps/db/supabase/migrations/20250703232000_add_whitelist_check.sql
@@ -1,0 +1,9 @@
+drop policy "Enable all access for authenticated users" on "public"."students";
+
+create policy "Enable all access for whitelisted users"
+on "public"."students"
+as permissive
+for all
+to authenticated
+using (EXISTS (SELECT 1 FROM workspace_members WHERE user_id = auth.uid()))
+with check (EXISTS (SELECT 1 FROM workspace_members WHERE user_id = auth.uid()));

--- a/apps/web/src/app/[locale]/(dashboard)/[wsId]/structure.tsx
+++ b/apps/web/src/app/[locale]/(dashboard)/[wsId]/structure.tsx
@@ -132,7 +132,7 @@ export function Structure({
   const sidebarHeader = (
     <>
       {isCollapsed || (
-        <Link href="/home" className="flex flex-none items-center gap-2">
+        <Link href="/" className="flex flex-none items-center gap-2">
           <div className="flex-none">
             <Image
               src="/media/logos/transparent.png"
@@ -227,7 +227,7 @@ export function Structure({
   const mobileHeader = (
     <>
       <div className="flex flex-none items-center gap-2">
-        <Link href="/home" className="flex flex-none items-center gap-2">
+        <Link href="/" className="flex flex-none items-center gap-2">
           <Image
             src="/media/logos/transparent.png"
             className="h-8 w-8"

--- a/apps/web/src/app/[locale]/(marketing)/login/form.tsx
+++ b/apps/web/src/app/[locale]/(marketing)/login/form.tsx
@@ -61,7 +61,7 @@ export default function LoginForm() {
 
       // if on DEV_MODE, auto-open inbucket
       if (DEV_MODE) {
-        window.open('http://localhost:8004/monitor', '_blank');
+        window.open('http://localhost:8004', '_blank');
       }
     }
   }, [otpSent]);
@@ -228,7 +228,7 @@ export default function LoginForm() {
           <div className="grid gap-2 md:grid-cols-2">
             {DEV_MODE ? (
               <Link
-                href="http://localhost:8004/monitor"
+                href="http://localhost:8004"
                 target="_blank"
                 className="col-span-full"
                 aria-disabled={loading}

--- a/apps/web/src/app/api/students/[id]/route.ts
+++ b/apps/web/src/app/api/students/[id]/route.ts
@@ -6,9 +6,10 @@ export async function GET(
   { params }: { params: Promise<{ id: string }> }
 ) {
   try {
+    const { id } = await params;
+
     const supabase = await createClient();
 
-    const { id } = await params;
     const { data: student, error } = await supabase
       .from('students')
       .select('*')
@@ -46,10 +47,11 @@ export async function PUT(
 ) {
   try {
     const { name, studentNumber, program } = await request.json();
+    const { id } = await params;
+
     const supabase = await createClient();
 
-    const { id } = await params;
-    const { data: student, error } = await supabase
+    const { error } = await supabase
       .from('students')
       .update({ name, student_number: studentNumber, program })
       .eq('id', id)
@@ -63,14 +65,10 @@ export async function PUT(
       );
     }
 
-    if (!student) {
-      return NextResponse.json(
-        { message: 'Student not found' },
-        { status: 404 }
-      );
-    }
-
-    return NextResponse.json({ student });
+    return NextResponse.json(
+      { message: 'Student updated successfully' },
+      { status: 200 }
+    );
   } catch (error) {
     console.error(error);
 
@@ -86,15 +84,11 @@ export async function DELETE(
   { params }: { params: Promise<{ id: string }> }
 ) {
   try {
+    const { id } = await params;
+
     const supabase = await createClient();
 
-    const { id } = await params;
-    const { data: student, error } = await supabase
-      .from('students')
-      .delete()
-      .eq('id', id)
-      .select()
-      .single();
+    const { error } = await supabase.from('students').delete().eq('id', id);
 
     if (error) {
       return NextResponse.json(
@@ -103,14 +97,10 @@ export async function DELETE(
       );
     }
 
-    if (!student) {
-      return NextResponse.json(
-        { message: 'Student not found' },
-        { status: 404 }
-      );
-    }
-
-    return NextResponse.json({ message: 'Student deleted' });
+    return NextResponse.json(
+      { message: 'Student deleted successfully' },
+      { status: 200 }
+    );
   } catch (error) {
     console.error(error);
 

--- a/apps/web/src/app/api/students/route.ts
+++ b/apps/web/src/app/api/students/route.ts
@@ -57,18 +57,15 @@ export async function GET(request: Request) {
 export async function POST(request: Request) {
   try {
     const { name, studentNumber, program, timestamp } = await request.json();
+
     const supabase = await createClient();
 
-    const { data: student, error } = await supabase
-      .from('students')
-      .insert({
-        name,
-        student_number: studentNumber,
-        program,
-        created_at: timestamp,
-      })
-      .select()
-      .single();
+    const { error } = await supabase.from('students').insert({
+      name,
+      student_number: studentNumber,
+      program,
+      created_at: timestamp,
+    });
 
     if (error) {
       return NextResponse.json(
@@ -77,7 +74,10 @@ export async function POST(request: Request) {
       );
     }
 
-    return NextResponse.json({ student });
+    return NextResponse.json(
+      { message: 'Students added successfully' },
+      { status: 200 }
+    );
   } catch (error) {
     console.error(error);
 

--- a/apps/web/src/constants/public_paths.ts
+++ b/apps/web/src/constants/public_paths.ts
@@ -1,7 +1,6 @@
 import { supportedLocales } from '@/i18n/routing';
 
 export const APP_PUBLIC_PATHS = [
-  '/',
   '/login',
   '/about',
   '/projects',

--- a/apps/web/src/constants/public_paths.ts
+++ b/apps/web/src/constants/public_paths.ts
@@ -1,7 +1,7 @@
 import { supportedLocales } from '@/i18n/routing';
 
 export const APP_PUBLIC_PATHS = [
-  '/home',
+  '/',
   '/login',
   '/about',
   '/projects',


### PR DESCRIPTION
The scanner page can now be accessed to whitelisted users only (those who are members of workspaces regardless of any roles). For students data that can not be uploaded to database, the logic for handling error is implemented to replace the incorrect success messages appeared to users before.