### PR TITLE
fix: Enhance sitemap with locales and priorities

### DIFF
--- a/apps/web/src/app/sitemap.ts
+++ b/apps/web/src/app/sitemap.ts
@@ -1,22 +1,41 @@
 import type { MetadataRoute } from 'next';
-import { BASE_URL, PUBLIC_PATHS } from '@/constants/common';
+import { BASE_URL } from '@/constants/common';
 
 export default function sitemap(): MetadataRoute.Sitemap {
-  const langSlugs = ['', 'en', 'vi']; // Add more language slugs as needed
+  const locales = ['', '/en', '/vi'];
 
-  // Generate URLs for both English and Vietnamese
+  // Define paths with their priorities and change frequencies
+  const routes: {
+    path: string;
+    priority: number;
+    changeFrequency: MetadataRoute.Sitemap[number]['changeFrequency'];
+  }[] = [
+    { path: '', priority: 1.0, changeFrequency: 'weekly' }, // Homepage
+    { path: '/about', priority: 0.9, changeFrequency: 'monthly' },
+    { path: '/achievements', priority: 0.8, changeFrequency: 'monthly' },
+    { path: '/projects', priority: 0.8, changeFrequency: 'monthly' },
+    { path: '/branding', priority: 0.6, changeFrequency: 'monthly' },
+    { path: '/contributors', priority: 0.7, changeFrequency: 'monthly' },
+    { path: '/meet-together', priority: 0.5, changeFrequency: 'monthly' },
+    { path: '/neo-generator', priority: 0.5, changeFrequency: 'monthly' },
+    { path: '/neo-meeting-agent', priority: 0.5, changeFrequency: 'monthly' },
+    { path: '/neo-crush', priority: 0.4, changeFrequency: 'yearly' },
+    { path: '/neo-chess', priority: 0.4, changeFrequency: 'yearly' },
+    { path: '/neo-pacman', priority: 0.4, changeFrequency: 'yearly' },
+  ];
+
   const urls: MetadataRoute.Sitemap = [];
 
-  // Non-language-specific routes
-  PUBLIC_PATHS.forEach((route, index) => {
-    langSlugs.forEach((lang) => {
+  for (const route of routes) {
+    for (const locale of locales) {
       urls.push({
-        url: `${BASE_URL}${lang}${route}`,
+        url: `${BASE_URL}${locale}${route.path}`,
         lastModified: new Date(),
-        priority: index === 0 ? 1.0 : 0.8,
+        changeFrequency: route.changeFrequency,
+        priority: route.priority,
       });
-    });
-  });
+    }
+  }
 
   return urls;
 }


### PR DESCRIPTION
Replace PUBLIC_PATHS-based generation with an explicit routes array and locales list. Each route now includes priority and changeFrequency metadata, and sitemap entries are generated for '', '/en', and '/vi' prefixes using BASE_URL. Removed unused PUBLIC_PATHS import and set lastModified on each URL to enable finer control over crawl priority and update frequency.