### PR TITLE
refactor: Rebrand metadata to Neo League and add JSON-LD

### DIFF
--- a/apps/neo-league/src/app/layout.tsx
+++ b/apps/neo-league/src/app/layout.tsx
@@ -14,15 +14,16 @@ export const metadata: Metadata = {
   metadataBase: new URL(BASE_URL),
   title: {
     default:
-      'RMIT NEO League 2026 | Innovation Humanity Challenge — IoT Competition',
-    template: '%s | RMIT NEO League 2026',
+      'Neo League 2026 — RMIT IoT Competition & Innovation Humanity Challenge',
+    template: '%s | Neo League 2026 — RMIT IoT Competition',
   },
   description:
     'RMIT NEO League Season 2 — the premier IoT competition for university students in Vietnam. Hosted by RMIT NEO Culture Technology Club, teams engineer integrated IoT solutions addressing UN Sustainable Development Goals through hardware prototyping, sensor integration, and smart technologies. March 2 – May 29, 2026, Ho Chi Minh City.',
   keywords: [
     // Brand keywords
+    'Neo League',
+    'Neo League 2026',
     'RMIT NEO League',
-    'NEO League',
     'RMIT Neo League 2026',
     'Neo Culture Technology',
     'RMIT NCT',
@@ -86,13 +87,13 @@ export const metadata: Metadata = {
     },
   },
   openGraph: {
-    title: 'RMIT NEO League 2026 | IoT Competition & Innovation Challenge',
+    title: 'Neo League 2026 — RMIT IoT Competition & Innovation Challenge',
     description:
-      "Vietnam's premier student IoT competition — engineer integrated hardware and IoT solutions addressing UN Sustainable Development Goals. Hosted by RMIT NEO Culture Technology Club.",
+      "Neo League is Vietnam's premier student IoT competition — engineer integrated hardware and IoT solutions addressing UN Sustainable Development Goals. Hosted by RMIT NEO Culture Technology Club.",
     type: 'website',
     locale: 'en_US',
     url: BASE_URL,
-    siteName: 'RMIT NEO League — IoT Competition',
+    siteName: 'Neo League — RMIT IoT Competition',
     images: [
       {
         url: '/logo.png',
@@ -104,9 +105,9 @@ export const metadata: Metadata = {
   },
   twitter: {
     card: 'summary_large_image',
-    title: 'RMIT NEO League 2026 | IoT Competition & Innovation Challenge',
+    title: 'Neo League 2026 — RMIT IoT Competition & Innovation Challenge',
     description:
-      "Vietnam's premier student IoT competition — engineer IoT solutions for UN SDGs. Join RMIT NEO Culture Technology Club's hardware innovation challenge.",
+      "Neo League — Vietnam's premier student IoT competition. Engineer IoT solutions for UN SDGs. Join RMIT NEO Culture Technology Club's hardware innovation challenge.",
     images: ['/logo.png'],
   },
   alternates: {

--- a/apps/neo-league/src/components/hero-section.tsx
+++ b/apps/neo-league/src/components/hero-section.tsx
@@ -38,7 +38,7 @@ export default function HeroSection() {
 
           {/* SEO: Visually hidden h1 for search engines */}
           <h1 className="sr-only">
-            RMIT NEO League 2026 — IoT Competition & Innovation Humanity
+            NEO League 2026 — RMIT IoT Competition & Innovation Humanity
             Challenge | Student IoT Hackathon Vietnam
           </h1>
 

--- a/apps/neo-league/src/components/json-ld.tsx
+++ b/apps/neo-league/src/components/json-ld.tsx
@@ -5,9 +5,11 @@ const eventData = {
   '@type': ['Event', 'Hackathon'],
   name: 'Neo League 2026 - Innovation Humanity Challenge',
   alternateName: [
+    'Neo League',
+    'Neo League 2026',
+    'RMIT NEO League',
     'RMIT IoT Competition 2026',
     'NEO League Season 2',
-    'RMIT NEO League',
   ],
   description:
     'RMIT NEO League Season 2 is the premier IoT competition for university students in Vietnam. Hosted by RMIT NEO Culture Technology Club, teams engineer integrated IoT and hardware solutions addressing UN Sustainable Development Goals through prototyping, sensor integration, and smart technologies.',
@@ -96,6 +98,34 @@ const orgData = {
   ],
 };
 
+const websiteData = {
+  '@context': 'https://schema.org',
+  '@type': 'WebSite',
+  name: 'Neo League',
+  alternateName: ['RMIT NEO League', 'Neo League 2026'],
+  url: BASE_URL,
+  description:
+    "Neo League is Vietnam's premier student IoT competition hosted by RMIT NEO Culture Technology Club. University students engineer integrated hardware and IoT solutions addressing UN Sustainable Development Goals.",
+  publisher: {
+    '@type': 'Organization',
+    name: 'RMIT NEO Culture Technology Club',
+    url: 'https://rmitnct.club',
+  },
+};
+
+const breadcrumbData = {
+  '@context': 'https://schema.org',
+  '@type': 'BreadcrumbList',
+  itemListElement: [
+    {
+      '@type': 'ListItem',
+      position: 1,
+      name: 'Neo League 2026',
+      item: BASE_URL,
+    },
+  ],
+};
+
 export default function JsonLd() {
   return (
     <head>
@@ -104,6 +134,12 @@ export default function JsonLd() {
       </script>
       <script type="application/ld+json" suppressHydrationWarning>
         {JSON.stringify(orgData)}
+      </script>
+      <script type="application/ld+json" suppressHydrationWarning>
+        {JSON.stringify(websiteData)}
+      </script>
+      <script type="application/ld+json" suppressHydrationWarning>
+        {JSON.stringify(breadcrumbData)}
       </script>
     </head>
   );


### PR DESCRIPTION
Update site metadata and SEO to use "Neo League" as the primary name (titles, templates, keywords, OpenGraph and Twitter fields) and adjust the hidden h1 in the hero for consistency. Expand JSON-LD with additional alternate names and new WebSite and BreadcrumbList objects to improve structured data and search visibility.