### PR TITLE
add see full document button

### DIFF
--- a/apps/neo-league/src/components/rules-section.tsx
+++ b/apps/neo-league/src/components/rules-section.tsx
@@ -3,6 +3,8 @@ import {
   CheckCircle2,
   Component,
   Cpu,
+  ExternalLink,
+  FileText,
   Gavel,
   Trophy,
   UserCheck,
@@ -137,6 +139,29 @@ export default function RulesSection() {
               </ul>
             </div>
           </div>
+        </div>
+
+        {/* Full Regulations CTA */}
+        <div className="mt-10 flex justify-center">
+          <a
+            href="https://drive.google.com/file/d/1_5nPwmZz8aykH46vnTYjRGQDm7BBIRKi/view?usp=sharing"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="group flex items-center gap-3 rounded-2xl border border-brand-teal/30 bg-background/60 px-7 py-4 text-brand-teal transition-all hover:border-brand-teal hover:bg-brand-teal/10 hover:shadow-lg hover:shadow-brand-teal/10"
+          >
+            <div className="flex h-9 w-9 items-center justify-center rounded-lg bg-brand-teal/10 transition-colors group-hover:bg-brand-teal/20">
+              <FileText className="h-5 w-5" />
+            </div>
+            <div className="text-left">
+              <p className="font-black text-sm uppercase tracking-wider">
+                Full Rules & Regulations
+              </p>
+              <p className="text-muted-foreground text-xs">
+                Read the complete competition guidelines
+              </p>
+            </div>
+            <ExternalLink className="ml-1 h-4 w-4 opacity-60 transition-opacity group-hover:opacity-100" />
+          </a>
         </div>
       </div>
     </section>


### PR DESCRIPTION
<img width="1321" height="871" alt="image" src="https://github.com/user-attachments/assets/109e5a67-a9f7-4904-bd89-6e1f966f8f9d" />
add button to view full documentation
Closes #287 